### PR TITLE
implement volunteer heatmap

### DIFF
--- a/src/components/volunteer-availabilities/HeatMap.jsx
+++ b/src/components/volunteer-availabilities/HeatMap.jsx
@@ -1,42 +1,50 @@
 import React, { useEffect } from 'react';
 import Chart from 'react-apexcharts';
+// import ApexCharts from 'apexcharts';
+import { PropTypes } from 'prop-types';
 import { AFCBackend, dayOfWeek } from '../../util/utils';
 
-const HeatMap = () => {
+const afterTimes = {
+  '08:00AM': '08:30AM',
+  '08:30AM': '09:00AM',
+  '09:00AM': '09:30AM',
+  '09:30AM': '10:00AM',
+  '10:00AM': '10:30AM',
+  '10:30AM': '11:00AM',
+  '11:00AM': '11:30AM',
+  '11:30AM': '12:00PM',
+  '12:00PM': '12:30PM',
+  '12:30PM': '13:00PM',
+  '13:00PM': '13:30PM',
+  '13:30PM': '14:00PM',
+  '14:00PM': '14:30PM',
+  '14:30PM': '15:00PM',
+  '15:00PM': '15:30PM',
+  '15:30PM': '16:00PM',
+  '16:00PM': '16:30PM',
+  '16:30PM': '17:00PM',
+  '17:00PM': '17:30PM',
+};
+
+const timePairs = Object.entries(afterTimes).map(([start, end]) => [
+  start.substring(0, 5),
+  end.substring(0, 5),
+]);
+
+const HeatMap = ({ onSelectedTimeslot }) => {
   const [options, setOptions] = React.useState(null);
   const [series, setSeries] = React.useState([]);
 
   const generateData = (startHour, endHour, data) => {
     return dayOfWeek.map(x => {
       const timestring = `${x} ${startHour.substring(0, 5)} to ${endHour.substring(0, 5)}`;
-      const y = data[timestring] ? data[timestring] + 1 : 1; // value of each cell, remove + 1, set default as 0 during prod
+      const y = data[timestring] ? data[timestring] : 0; // value of each cell, remove + 1, set default as 0 during prod
       return { x, y };
     });
   };
 
   const generateSeries = async (startHour, endHour) => {
     const times = [];
-    const afterTimes = {
-      '08:00AM': '08:30AM',
-      '08:30AM': '09:00AM',
-      '09:00AM': '09:30AM',
-      '09:30AM': '10:00AM',
-      '10:00AM': '10:30AM',
-      '10:30AM': '11:00AM',
-      '11:00AM': '11:30AM',
-      '11:30AM': '12:00PM',
-      '12:00PM': '12:30PM',
-      '12:30PM': '13:00PM',
-      '13:00PM': '13:30PM',
-      '13:30PM': '14:00PM',
-      '14:00PM': '14:30PM',
-      '14:30PM': '15:00PM',
-      '15:00PM': '15:30PM',
-      '15:30PM': '16:00PM',
-      '16:00PM': '16:30PM',
-      '16:30PM': '17:00PM',
-      '17:00PM': '17:30PM',
-    };
     const { data } = await AFCBackend.get('/volunteers/available');
     for (let hour = startHour; hour <= endHour; hour += 1) {
       const formattedHour = hour < 10 ? `0${String(hour)}` : String(hour);
@@ -51,7 +59,21 @@ const HeatMap = () => {
       name: time,
       data: generateData(time, afterTimes[time], data),
     }));
+    // console.log(generatedSeries);
     await setSeries(generatedSeries);
+  };
+
+  const onSquareClick = (event, chartContext, config) => {
+    // Get square coordinates
+    const rowIndex = config.seriesIndex;
+    const colIndex = config.dataPointIndex;
+
+    // Convert to readable date and time
+    const day = dayOfWeek[colIndex];
+    const time = timePairs[18 - rowIndex];
+
+    // Update selected time
+    onSelectedTimeslot(day, time);
   };
 
   useEffect(() => {
@@ -70,6 +92,9 @@ const HeatMap = () => {
             speed: 5,
           },
         },
+        events: {
+          dataPointSelection: onSquareClick,
+        },
       },
       dataLabels: {
         enabled: false,
@@ -86,6 +111,10 @@ const HeatMap = () => {
   return (
     options && <Chart options={options} series={series} type="heatmap" width="800" height="500" />
   );
+};
+
+HeatMap.propTypes = {
+  onSelectedTimeslot: PropTypes.func.isRequired,
 };
 
 export default HeatMap;

--- a/src/components/volunteer-availabilities/HeatMap.jsx
+++ b/src/components/volunteer-availabilities/HeatMap.jsx
@@ -1,35 +1,17 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Chart from 'react-apexcharts';
-// import ApexCharts from 'apexcharts';
-import { AFCBackend } from '../../util/utils';
+import { AFCBackend, dayOfWeek } from '../../util/utils';
 
 const HeatMap = () => {
   const [options, setOptions] = React.useState(null);
   const [series, setSeries] = React.useState([]);
 
-  const generateData = (count, startHour, endHour, data) => {
-    const dayOfWeek = [
-      'sunday',
-      'monday',
-      'tuesday',
-      'wednesday',
-      'thursday',
-      'friday',
-      'saturday',
-    ];
-    let i = 0;
-    const generatedSeries = [];
-    while (i < count) {
-      const x = dayOfWeek[i];
+  const generateData = (startHour, endHour, data) => {
+    return dayOfWeek.map(x => {
       const timestring = `${x} ${startHour.substring(0, 5)} to ${endHour.substring(0, 5)}`;
       const y = data[timestring] ? data[timestring] + 1 : 1; // value of each cell, remove + 1, set default as 0 during prod
-      generatedSeries.push({
-        x,
-        y,
-      });
-      i += 1;
-    }
-    return generatedSeries;
+      return { x, y };
+    });
   };
 
   const generateSeries = async (startHour, endHour) => {
@@ -44,7 +26,7 @@ const HeatMap = () => {
       '11:00AM': '11:30AM',
       '11:30AM': '12:00PM',
       '12:00PM': '12:30PM',
-      '12:30PM': '1:00PM',
+      '12:30PM': '13:00PM',
       '13:00PM': '13:30PM',
       '13:30PM': '14:00PM',
       '14:00PM': '14:30PM',
@@ -55,10 +37,7 @@ const HeatMap = () => {
       '16:30PM': '17:00PM',
       '17:00PM': '17:30PM',
     };
-    let data = {};
-    await AFCBackend.get('/volunteers/available').then(res => {
-      data = res.data;
-    });
+    const { data } = await AFCBackend.get('/volunteers/available');
     for (let hour = startHour; hour <= endHour; hour += 1) {
       const formattedHour = hour < 10 ? `0${String(hour)}` : String(hour);
       const period = hour >= 12 ? 'PM' : 'AM';
@@ -68,16 +47,14 @@ const HeatMap = () => {
       }
     }
 
-    const generatedSeries = times.reverse().map(time => {
-      return {
-        name: time,
-        data: generateData(7, time, afterTimes[time], data),
-      };
-    });
+    const generatedSeries = times.reverse().map(time => ({
+      name: time,
+      data: generateData(time, afterTimes[time], data),
+    }));
     await setSeries(generatedSeries);
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     const values = {
       chart: {
         id: 'availability',
@@ -106,17 +83,8 @@ const HeatMap = () => {
     generateSeries(9, 17);
   }, []);
 
-  const renderChart = () => {
-    if (options) {
-      return <Chart options={options} series={series} type="heatmap" width="800" height="500" />;
-    }
-    return null;
-  };
-
   return (
-    <div>
-      <div className="mixed-chart"> {renderChart()} </div>
-    </div>
+    options && <Chart options={options} series={series} type="heatmap" width="800" height="500" />
   );
 };
 

--- a/src/components/volunteer-availabilities/VolunteerAvailability.jsx
+++ b/src/components/volunteer-availabilities/VolunteerAvailability.jsx
@@ -4,6 +4,7 @@ import HeatMap from './HeatMap';
 import { AFCBackend } from '../../util/utils';
 
 const VolunteerAvailability = ({ handleViewDatabase }) => {
+  const [selectedTimeslot, setSelectedTimeslot] = useState({});
   const [volunteers, setVolunteers] = useState([]);
   const [availableVolunteers, setAvailableVolunteers] = useState([]);
   const [filteredVolunteers, setFilteredVolunteers] = useState([]);
@@ -22,22 +23,22 @@ const VolunteerAvailability = ({ handleViewDatabase }) => {
     setFilteredVolunteers(availables);
   }, []);
 
-  const onSelectedTimeslot = async (day, time) => {
-    // reading state variables here always returns their default value
-    if (availableVolunteers.length) {
-      // console.log(availableVolunteers);
+  useEffect(async () => {
+    const { day, time } = selectedTimeslot;
+    if (selectedTimeslot === {} || !day || !time) {
       setFilteredVolunteers(availableVolunteers);
       return;
     }
+    const [start, end] = time;
     const { data } = await AFCBackend.get(
-      `volunteers/available/day/${day}/start/${time[0]}/end/${time[1]}`,
+      `volunteers/available/day/${day}/start/${start}/end/${end}`,
     );
     const processedData = data.map(e => {
       const { first_name: firstName, last_name: lastName, user_id: id } = e;
       return { id, firstName, lastName };
     });
     setFilteredVolunteers(processedData);
-  };
+  }, [selectedTimeslot]);
 
   return (
     <div className="volunteer-availabilities">
@@ -82,7 +83,7 @@ const VolunteerAvailability = ({ handleViewDatabase }) => {
             </label>
           </div>
         </div>
-        <HeatMap onSelectedTimeslot={onSelectedTimeslot} />
+        <HeatMap setSelectedTimeslot={setSelectedTimeslot} />
       </div>
       <div className="available-volunteers">
         <h2>

--- a/src/components/volunteer-availabilities/VolunteerAvailability.jsx
+++ b/src/components/volunteer-availabilities/VolunteerAvailability.jsx
@@ -1,156 +1,22 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import HeatMap from './HeatMap';
+import { AFCBackend } from '../../util/utils';
 
-const VolunteerAvailability = props => {
-  const { handleViewDatabase } = props;
-  const VOLUNTEERS_DUMMY_DATA = [
-    {
-      id: 0,
-      name: 'John Stone',
-      available: true,
-    },
-    {
-      id: 1,
-      name: 'Ponnappa Priya',
-      available: true,
-    },
-    {
-      id: 2,
-      name: 'Mia Wong',
-      available: true,
-    },
-    {
-      id: 3,
-      name: 'Peter Stanbridge',
-      available: true,
-    },
-    {
-      id: 4,
-      name: 'Natalie Lee-Walsh',
-      available: true,
-    },
-    {
-      id: 5,
-      name: 'Ang Li',
-      available: true,
-    },
-    {
-      id: 6,
-      name: 'Nguta Ithya',
-      available: true,
-    },
-    {
-      id: 7,
-      name: 'John Stone',
-      available: true,
-    },
-    {
-      id: 8,
-      name: 'Ponnappa Priya',
-      available: true,
-    },
-    {
-      id: 9,
-      name: 'Mia Wong',
-      available: true,
-    },
-    {
-      id: 10,
-      name: 'Peter Stanbridge',
-      available: true,
-    },
-    {
-      id: 11,
-      name: 'Natalie Lee-Walsh',
-      available: true,
-    },
-    {
-      id: 12,
-      name: 'Ang Li',
-      available: true,
-    },
-    {
-      id: 13,
-      name: 'Nguta Ithya',
-      available: true,
-    },
-    {
-      id: 14,
-      name: 'John Stone',
-      available: true,
-    },
-    {
-      id: 15,
-      name: 'Ponnappa Priya',
-      available: true,
-    },
-    {
-      id: 16,
-      name: 'Mia Wong',
-      available: true,
-    },
-    {
-      id: 17,
-      name: 'Peter Stanbridge',
-      available: true,
-    },
-    {
-      id: 18,
-      name: 'Natalie Lee-Walsh',
-      available: true,
-    },
-    {
-      id: 19,
-      name: 'Ang Li',
-      available: true,
-    },
-    {
-      id: 20,
-      name: 'Nguta Ithya',
-      available: true,
-    },
-    {
-      id: 21,
-      name: 'John Stone',
-      available: false,
-    },
-    {
-      id: 22,
-      name: 'Ponnappa Priya',
-      available: false,
-    },
-    {
-      id: 23,
-      name: 'Mia Wong',
-      available: false,
-    },
-    {
-      id: 24,
-      name: 'Peter Stanbridge',
-      available: false,
-    },
-    {
-      id: 25,
-      name: 'Natalie Lee-Walsh',
-      available: false,
-    },
-    {
-      id: 26,
-      name: 'Ang Li',
-      available: false,
-    },
-  ];
-
-  const showDatabase = () => {
-    handleViewDatabase();
-  };
+const VolunteerAvailability = ({ handleViewDatabase }) => {
   const [volunteers, setVolunteers] = useState([]);
   const [availableVolunteers, setAvailableVolunteers] = useState([]);
 
-  useEffect(() => {
-    setVolunteers(VOLUNTEERS_DUMMY_DATA);
-    setAvailableVolunteers(VOLUNTEERS_DUMMY_DATA.filter(v => v.available));
+  useEffect(async () => {
+    const { data } = await AFCBackend.get('/volunteers/');
+    const mappedVolunteers = data.map(({ userId, firstName, lastName, availabilities }) => ({
+      id: userId,
+      firstName,
+      lastName,
+      available: !!availabilities,
+    }));
+    setVolunteers(mappedVolunteers);
+    setAvailableVolunteers(mappedVolunteers.filter(v => v.available));
   }, []);
 
   return (
@@ -166,7 +32,7 @@ const VolunteerAvailability = props => {
               id="search-volunteers"
             />
             <div className="right-align">
-              <button type="button" onClick={showDatabase}>
+              <button type="button" onClick={handleViewDatabase}>
                 View Database
               </button>
               <button type="button">Export</button>
@@ -202,16 +68,11 @@ const VolunteerAvailability = props => {
         <h2>
           Volunteers ({availableVolunteers.length}/{volunteers.length})
         </h2>
-        {availableVolunteers.map(v => {
-          const nameArr = v.name.split(' ');
-          const lastName = nameArr[1];
-          const firstName = nameArr[0];
-          return (
-            <p key={v.id}>
-              {lastName}, {firstName}
-            </p>
-          );
-        })}
+        {availableVolunteers.map(({ id, firstName, lastName }) => (
+          <p key={id}>
+            {lastName}, {firstName}
+          </p>
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
### What changes are included in this PR?

#### Heatmap
- Refactored a lot of smelly code
- Formatted heatmap to actually use backend info (the original issue was that keys weren't properly capitalized)
- Able to select a cell and volunteer list shows the available volunteers at that timeslot
   - Clicking the same cell again will reset the volunteer list, effectively deselecting the cell

#### Backend Routes
- Both /volunteers and /volunteers/available were broken because of new payload params not being optional, fixed now

#### Volunteer Availability
- Grabbed volunteer list from backend

### Instructions to test changes:
#### Heatmap
- Cross reference the heatmap numbers with backend tables
- Double check the time formats are correct and properly ordered
- Cross reference the volunteer list based on availability selection
- Test toggling a cell

#### Backend Routes
- Test /volunteers and /volunteers/available so that they still work with and without the new payload params

#### Volunteer Availability
- Cross reference the volunteer list with backend tables

### Images
![Screenshot 2022-09-23 231051](https://user-images.githubusercontent.com/66648948/192082908-48056d3b-2ce8-4f2f-8a95-d88b92b7f1c1.png)

### Todo
- Heatmap currently is one indexed, so timeslots that have no volunteer availability are set to 1 instead of 0, and everything else is incremented by 1 as well (motivation is that the chart doesn't show the timeslot square without a nonzero value)
- Nothing on that page is interactable other than the chart and the "View Database" button, not sure if that's by design

closes #159